### PR TITLE
Fix ajax_url_mfb without rewrite url

### DIFF
--- a/views/js/delivery_locations.js
+++ b/views/js/delivery_locations.js
@@ -56,9 +56,6 @@ function toggle_map_display(e)
 };
 
 function load_locations(carrier_id) {
-	// Prestashop 1.7 compatibility. For some reason the ajax URL is escaped despite smarty filter to unescape it
-	ajax_url_mfb = ajax_url_mfb.replace(/&amp;/g, '&');
-	
   jQuery.ajax({
     url: ajax_url_mfb,
 	type: 'POST',

--- a/views/templates/hooks/relay_delivery.tpl
+++ b/views/templates/hooks/relay_delivery.tpl
@@ -33,7 +33,7 @@ var customer_lastname="{$customer_lastname|escape:'javascript':'UTF-8'}";
 var customer_firstname="{$customer_firstname|escape:'javascript':'UTF-8'}";
 var cart_id="{$cart_id|escape:'javascript':'UTF-8'}";
 var carrier_ids="{$carrier_ids|escape:'javascript':'UTF-8'}".split('-');
-var ajax_url_mfb="{$link->getModuleLink('lowcostexpress','relay',[])|unescape:'html'}";
+var ajax_url_mfb="{$link->getModuleLink('lowcostexpress','relay',[]) nofilter}";
 var oldCodePostal=null;
 var errormessage="{l s='No relay location has been selected ! Please select a location to continue.' mod='lowcostexpress'}";
 


### PR DESCRIPTION
Quand la ré-écriture d'url est activée, l'url est au format : http://exemple.com/module/lowcostexpress/relay

Pour le cas où la ré-écriture d'url n'est pas activée,, il faut retirer le filtre sur les caractères spéciaux avec "nofilter" : 

var ajax_url_mfb="{$link->getModuleLink('lowcostexpress','relay',[]) nofilter}";
